### PR TITLE
Add setSpatialListenersAudio REST API

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -22,4 +22,4 @@ jobs:
               if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
               uses: JS-DevTools/npm-publish@v1
               with:
-                token: ${{ secrets.NPM_TOKEN }}
+                  token: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dolby.io REST APIs
 
-Node.JS wrapper for the dolby.io REST [Communications](https://docs.dolby.io/interactivity/reference/authentication-api) APIs.
+Node.JS wrapper for the dolby.io REST [Communications](https://docs.dolby.io/communications-apis/reference/authentication-api) APIs.
 
 ## Install this project
 

--- a/src/communications/authentication.ts
+++ b/src/communications/authentication.ts
@@ -37,7 +37,7 @@ const getAccessToken = async (
 /**
  * Gets an access token to authenticate for API calls.
  *
- * @link https://docs.dolby.io/interactivity/reference/jwt
+ * @link https://docs.dolby.io/communications-apis/reference/jwt
  *
  * @param consumerKey Your Dolby.io Consumer Key.
  * @param consumerSecret Your Dolby.io Consumer Secret.
@@ -52,7 +52,7 @@ export const getApiAccessToken = async (consumerKey: string, consumerSecret: str
 /**
  * Gets a client access token to authenticate a session.
  *
- * @link https://docs.dolby.io/interactivity/reference/postoauthtoken-1
+ * @link https://docs.dolby.io/communications-apis/reference/postoauthtoken
  *
  * @param consumerKey Your Dolby.io Consumer Key.
  * @param consumerSecret Your Dolby.io Consumer Secret.

--- a/src/communications/conference.ts
+++ b/src/communications/conference.ts
@@ -1,5 +1,6 @@
-import { sendDelete, sendPost } from '../internal/httpHelpers';
+import { sendDelete, sendPost, sendPut } from '../internal/httpHelpers';
 import { CreateConferenceOptions, Conference, UserTokens } from './types/conference';
+import { SpatialEnvironment, SpatialListener, SpatialUsers } from './types/spatialAudio';
 import JwtToken from './types/jwtToken';
 import Participant from './types/participant';
 import { RTCPMode } from './types/rtcpMode';
@@ -127,6 +128,44 @@ export const kick = async (accessToken: JwtToken, conferenceId: string, external
     };
 
     await sendPost(options);
+};
+
+/**
+ * Sets the spatial audio scene for all listeners in an ongoing conference. This sets the spatial audio environment, the position and direction for all listeners with the spatialAudio flag enabled. The calls are not cumulative, and each call sets all the spatial listener values. Participants who do not have a position set are muted.
+ *
+ * @link https://docs.dolby.io/communications-apis/reference/putspatiallistenersaudio
+ *
+ * @param accessToken Access token to use for authentication.
+ * @param conferenceId Identifier of the conference.
+ * @param environment The spatial environment of an application, so the audio renderer understands which directions the application considers forward, up, and right and which units it uses for distance.
+ * @param listeners The listener's audio position and direction, defined using Cartesian coordinates.
+ * @param users The users' audio positions, defined using Cartesian coordinates.
+ */
+export const setSpatialListenersAudio = async (
+    accessToken: JwtToken,
+    conferenceId: string,
+    environment: SpatialEnvironment,
+    listeners: SpatialListener,
+    users: SpatialUsers
+): Promise<void> => {
+    const body = JSON.stringify({
+        environment: environment,
+        listeners: listeners,
+        users: users,
+    });
+
+    const options = {
+        hostname: 'api.voxeet.com',
+        path: `/v2/conferences/${conferenceId}/spatial-listeners-audio`,
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: `${accessToken.token_type} ${accessToken.access_token}`,
+        },
+        body,
+    };
+
+    await sendPut(options);
 };
 
 /**

--- a/src/communications/conference.ts
+++ b/src/communications/conference.ts
@@ -7,7 +7,7 @@ import { RTCPMode } from './types/rtcpMode';
 /**
  * Creates a conference.
  *
- * @link https://docs.dolby.io/interactivity/reference/postconferencecreate
+ * @link https://docs.dolby.io/communications-apis/reference/postconferencecreate
  *
  * @param accessToken Access token to use for authentication.
  * @param ownerExternalId External ID of the owner of the conference.
@@ -64,7 +64,7 @@ export const createConference = async (accessToken: JwtToken, options: CreateCon
 /**
  * Invites participants to an ongoing conference. This API can also be used to generate new conference access tokens for an ongoing conference. If the invite request includes participants that are already in the conference, a new conference access token is not generated and an invitation is not sent.
  *
- * @link https://docs.dolby.io/interactivity/reference/postconferenceinvite
+ * @link https://docs.dolby.io/communications-apis/reference/postconferenceinvite
  *
  * @param accessToken Access token to use for authentication.
  * @param conferenceId Identifier of the conference.
@@ -104,7 +104,7 @@ export const invite = async (accessToken: JwtToken, conferenceId: string, partic
 /**
  * Kicks participants from an ongoing conference.
  *
- * @link https://docs.dolby.io/interactivity/reference/postconferencekick
+ * @link https://docs.dolby.io/communications-apis/reference/postconferencekick
  *
  * @param accessToken Access token to use for authentication.
  * @param conferenceId Identifier of the conference.
@@ -132,7 +132,7 @@ export const kick = async (accessToken: JwtToken, conferenceId: string, external
 /**
  * Update permissions for participants in a conference. When a participant's permissions are updated, the new token is sent directly to the SDK. The SDK automatically receives, stores, and manages the new token and a `permissionsUpdated` event is sent.
  *
- * @link https://docs.dolby.io/interactivity/reference/postconferencepermissions
+ * @link https://docs.dolby.io/communications-apis/reference/postconferencepermissions
  *
  * @param accessToken Access token to use for authentication.
  * @param conferenceId Identifier of the conference.
@@ -172,7 +172,7 @@ export const updatePermissions = async (accessToken: JwtToken, conferenceId: str
 /**
  * Terminates an ongoing conference and removes all remaining participants from the conference.
  *
- * @link https://docs.dolby.io/interactivity/reference/deleteconference
+ * @link https://docs.dolby.io/communications-apis/reference/deleteconference
  *
  * @param accessToken Access token to use for authentication.
  * @param conferenceId Identifier of the conference.
@@ -195,7 +195,7 @@ export const terminate = async (accessToken: JwtToken, conferenceId: string): Pr
  * @deprecated
  * Destroys an ongoing conference and removes all remaining participants from the conference.
  *
- * @link https://docs.dolby.io/interactivity/reference/postconferencedestroy
+ * @link https://docs.dolby.io/communications-apis/reference/postconferencedestroy
  *
  * @param consumerKey Your Dolby.io Consumer Key.
  * @param consumerSecret Your Dolby.io Consumer Secret.

--- a/src/communications/conference.ts
+++ b/src/communications/conference.ts
@@ -138,19 +138,19 @@ export const kick = async (accessToken: JwtToken, conferenceId: string, external
  * @param accessToken Access token to use for authentication.
  * @param conferenceId Identifier of the conference.
  * @param environment The spatial environment of an application, so the audio renderer understands which directions the application considers forward, up, and right and which units it uses for distance.
- * @param listeners The listener's audio position and direction, defined using Cartesian coordinates.
+ * @param listener The listener's audio position and direction, defined using Cartesian coordinates.
  * @param users The users' audio positions, defined using Cartesian coordinates.
  */
 export const setSpatialListenersAudio = async (
     accessToken: JwtToken,
     conferenceId: string,
     environment: SpatialEnvironment,
-    listeners: SpatialListener,
+    listener: SpatialListener,
     users: SpatialUsers
 ): Promise<void> => {
     const body = JSON.stringify({
         environment: environment,
-        listeners: listeners,
+        listener: listener,
         users: users,
     });
 

--- a/src/communications/monitor/conferences.ts
+++ b/src/communications/monitor/conferences.ts
@@ -20,7 +20,7 @@ import { PagedResponse } from '../types/core';
  * **Note:** Only terminated conferences include a complete summary.
  * The summary of ongoing conferences includes the following fields in the response: `confId`, `alias`, `region`, `dolbyVoice`, `start`, `live`, `owner`.
  *
- * @link https://docs.dolby.io/interactivity/reference/getconferences
+ * @link https://docs.dolby.io/communications-apis/reference/getconferences
  *
  * @param accessToken Access token to use for authentication.
  * @param options Options to request the conferences.
@@ -76,7 +76,7 @@ export const listConferences = async (accessToken: JwtToken, options: ListConfer
  * **Note:** Only terminated conferences include a complete summary.
  * The summary of ongoing conferences includes the following fields in the response: `confId`, `alias`, `region`, `dolbyVoice`, `start`, `live`, `owner`.
  *
- * @link https://docs.dolby.io/interactivity/reference/getconferences
+ * @link https://docs.dolby.io/communications-apis/reference/getconferences
  *
  * @param accessToken Access token to use for authentication.
  * @param options Options to request the conferences.
@@ -128,7 +128,7 @@ export const listAllConferences = async (accessToken: JwtToken, options: ListAll
  * **Note:** Only terminated conferences include a complete summary.
  * The summary of ongoing conferences includes the following fields in the response: `confId`, `alias`, `region`, `dolbyVoice`, `start`, `live`, `owner`.
  *
- * @link https://docs.dolby.io/interactivity/reference/getconferencesummary
+ * @link https://docs.dolby.io/communications-apis/reference/getconferencesummary
  *
  * @param accessToken Access token to use for authentication.
  * @param conferenceId The identifier of the conference.
@@ -155,7 +155,7 @@ export const getConference = async (accessToken: JwtToken, conferenceId: string,
  *
  * **Note:** Only terminated conferences include a complete summary.
  *
- * @link https://docs.dolby.io/interactivity/reference/getconferencestatistics
+ * @link https://docs.dolby.io/communications-apis/reference/getconferencestatistics
  *
  * @param accessToken Access token to use for authentication.
  * @param conferenceId The identifier of the conference.
@@ -179,7 +179,7 @@ export const getConferenceStatistics = async (accessToken: JwtToken, conferenceI
 /**
  * Get statistics and connection details of all participants in a conference. Optionally limit the search result with a specific time range.
  *
- * @link https://docs.dolby.io/interactivity/reference/getconferenceparticipants
+ * @link https://docs.dolby.io/communications-apis/reference/getconferenceparticipants
  *
  * @param accessToken Access token to use for authentication.
  * @param options Options to request the participants.
@@ -231,7 +231,7 @@ export const getConferenceParticipants = async (accessToken: JwtToken, options: 
 /**
  * Get statistics and connection details of all participants in a conference. Optionally limit the search result with a specific time range.
  *
- * @link https://docs.dolby.io/interactivity/reference/getconferenceparticipants
+ * @link https://docs.dolby.io/communications-apis/reference/getconferenceparticipants
  *
  * @param accessToken Access token to use for authentication.
  * @param options Options to request the participants.

--- a/src/communications/monitor/recordings.ts
+++ b/src/communications/monitor/recordings.ts
@@ -8,7 +8,7 @@ import { GetRecordingsOptions, GetAllRecordingsOptions, GetRecordingsResponse, R
  * This API checks only the recordings that have ended during a specific time range.
  * Recordings are indexed based on the ending time.
  *
- * @link https://docs.dolby.io/interactivity/reference/getrecordings
+ * @link https://docs.dolby.io/communications-apis/reference/getrecordings
  *
  * @param accessToken Access token to use for authentication.
  * @param options Options to request the recordings.
@@ -53,7 +53,7 @@ export const getRecordings = async (accessToken: JwtToken, options: GetRecording
  * This API checks only the recordings that have ended during a specific time range.
  * Recordings are indexed based on the ending time.
  *
- * @link https://docs.dolby.io/interactivity/reference/getrecordings
+ * @link https://docs.dolby.io/communications-apis/reference/getrecordings
  *
  * @param accessToken Access token to use for authentication.
  * @param options Options to request the recordings.
@@ -93,7 +93,7 @@ export const getAllRecordings = async (accessToken: JwtToken, options: GetAllRec
  * This API checks the recordings that have ended during a specific time range.
  * Recordings are indexed based on the ending time.
  *
- * @link https://docs.dolby.io/interactivity/reference/getconferencerecordings
+ * @link https://docs.dolby.io/communications-apis/reference/getconferencerecordings
  *
  * @param accessToken Access token to use for authentication.
  * @param options Options to request the webhooks.
@@ -138,7 +138,7 @@ export const getRecording = async (accessToken: JwtToken, options: GetRecordingO
  *
  * **Warning**: After deleting the recording, it is not possible to restore the recording data.
  *
- * @link https://docs.dolby.io/interactivity/reference/deleteconferencerecordings
+ * @link https://docs.dolby.io/communications-apis/reference/deleteconferencerecordings
  *
  * @param accessToken Access token to use for authentication.
  * @param confId Identifier of the conference.
@@ -160,7 +160,7 @@ export const deleteRecording = async (accessToken: JwtToken, confId: string): Pr
  * Get details of all Dolby Voice-based audio recordings, and associated split recordings,
  * for a given conference and download the conference recording in the MP3 audio format.
  *
- * @link https://docs.dolby.io/interactivity/reference/getconferenceaudiorecording
+ * @link https://docs.dolby.io/communications-apis/reference/getconferenceaudiorecording
  *
  * @param accessToken Access token to use for authentication.
  * @param confId Identifier of the conference.
@@ -183,9 +183,9 @@ export const getDolbyVoiceRecording = async (accessToken: JwtToken, confId: stri
 
 /**
  * Download the conference recording in the MP4 video format.
- * For more information, see the [Recording](https://docs.dolby.io/interactivity/docs/recording) document.
+ * For more information, see the [Recording](https://docs.dolby.io/communications-apis/docs/guides-recording-mechanisms) document.
  *
- * @link https://docs.dolby.io/interactivity/reference/getconferencemp4recording
+ * @link https://docs.dolby.io/communications-apis/reference/getconferencemp4recording
  *
  * @param accessToken Access token to use for authentication.
  * @param confId Identifier of the conference.
@@ -206,9 +206,9 @@ export const downloadMp4Recording = async (accessToken: JwtToken, confId: string
 
 /**
  * Download the conference recording in the MP3 audio format.
- * For more information, see the [Recording](https://docs.dolby.io/interactivity/docs/recording) document.
+ * For more information, see the [Recording](https://docs.dolby.io/communications-apis/docs/guides-recording-mechanisms) document.
  *
- * @link https://docs.dolby.io/interactivity/reference/getconferencemp3recording
+ * @link https://docs.dolby.io/communications-apis/reference/getconferencemp3recording
  *
  * @param accessToken Access token to use for authentication.
  * @param confId Identifier of the conference.

--- a/src/communications/monitor/webhooks.ts
+++ b/src/communications/monitor/webhooks.ts
@@ -6,7 +6,7 @@ import { GetWebhooksOptions, GetAllWebhooksOptions, GetWebHookResponse, WebHook 
 /**
  * Gets a list of Webhook events sent, during a specific time range. The list includes associated endpoint response codes and headers.
  *
- * @link https://docs.dolby.io/interactivity/reference/getwebhooks
+ * @link https://docs.dolby.io/communications-apis/reference/getwebhooks
  *
  * @param accessToken Access token to use for authentication.
  * @param options Options to request the webhooks.
@@ -58,7 +58,7 @@ export const getEvents = async (accessToken: JwtToken, options: GetWebhooksOptio
 /**
  * Gets a list of all Webhook events sent, during a specific time range. The list includes associated endpoint response codes and headers.
  *
- * @link https://docs.dolby.io/interactivity/reference/getwebhooks
+ * @link https://docs.dolby.io/communications-apis/reference/getwebhooks
  *
  * @param accessToken Access token to use for authentication.
  * @param options Options to request the webhooks.

--- a/src/communications/remix.ts
+++ b/src/communications/remix.ts
@@ -7,7 +7,7 @@ import RemixStatus from './types/remixStatus';
  * the current mixer layout. The `Recording.MP4.Available` event is sent if the customer has configured
  * the webhook in the developer portal.
  *
- * @link https://docs.dolby.io/interactivity/reference/postconferencemixstart
+ * @link https://docs.dolby.io/communications-apis/reference/postconferencemixstart
  *
  * @param accessToken Access token to use for authentication.
  * @param conferenceId Identifier of the conference.
@@ -35,7 +35,7 @@ export const start = async (accessToken: JwtToken, conferenceId: string): Promis
  * the current mixer layout. The `Recording.MP4.Available` event is sent if the customer has configured
  * the webhook in the developer portal.
  *
- * @link https://docs.dolby.io/interactivity/reference/postconferencemixcreate
+ * @link https://docs.dolby.io/communications-apis/reference/postconferencemixcreate
  *
  * @param consumerKey Your Dolby.io Consumer Key.
  * @param consumerSecret Your Dolby.io Consumer Secret.
@@ -62,7 +62,7 @@ export const startBasicAuth = async (consumerKey: string, consumerSecret: string
 /**
  * Gets the status of a current mixing job. You must use this API if the conference is protected using enhanced conference access control.
  *
- * @link https://docs.dolby.io/interactivity/reference/postconferenceremixstatus
+ * @link https://docs.dolby.io/communications-apis/reference/getconferenceremixstatus
  *
  * @param accessToken Access token to use for authentication.
  * @param conferenceId Identifier of the conference.
@@ -87,7 +87,7 @@ export const getStatus = async (accessToken: JwtToken, conferenceId: string): Pr
  * @deprecated
  * Gets the status of a current mixing job.
  *
- * @link https://docs.dolby.io/interactivity/reference/postconferencemixstatus
+ * @link https://docs.dolby.io/communications-apis/reference/getconferencemixstatus
  *
  * @param consumerKey Your Dolby.io Consumer Key.
  * @param consumerSecret Your Dolby.io Consumer Secret.

--- a/src/communications/streaming.ts
+++ b/src/communications/streaming.ts
@@ -6,7 +6,7 @@ import JwtToken from './types/jwtToken';
  * a `Stream.Rtmp.InProgress` Webhook event will be sent. You must use this API if the conference is protected
  * using enhanced conference access control.
  *
- * @link https://docs.dolby.io/interactivity/reference/postrtmpstart
+ * @link https://docs.dolby.io/communications-apis/reference/postrtmpstart
  *
  * @param accessToken Access token to use for authentication.
  * @param conferenceId Identifier of the conference.
@@ -34,7 +34,7 @@ export const startRtmp = async (accessToken: JwtToken, conferenceId: string, rtm
  * Starts an RTMP live stream. Once the Dolby.io Communication API service started streaming to the target url,
  * a `Stream.Rtmp.InProgress` Webhook event will be sent.
  *
- * @link https://docs.dolby.io/interactivity/reference/postrtmpstartv1
+ * @link https://docs.dolby.io/communications-apis/reference/postrtmpstartv1
  *
  * @param consumerKey Your Dolby.io Consumer Key.
  * @param consumerSecret Your Dolby.io Consumer Secret.
@@ -67,7 +67,7 @@ export const startRtmpBasicAuth = async (
 /**
  * Stops an RTMP stream. You must use this API if the conference is protected using enhanced conference access control.
  *
- * @link https://docs.dolby.io/interactivity/reference/postrtmpstop
+ * @link https://docs.dolby.io/communications-apis/reference/postrtmpstop
  *
  * @param accessToken Access token to use for authentication.
  * @param conferenceId Identifier of the conference.
@@ -90,7 +90,7 @@ export const stopRtmp = async (accessToken: JwtToken, conferenceId: string): Pro
  * @deprecated
  * Stops an RTMP stream.
  *
- * @link https://docs.dolby.io/interactivity/reference/postrtmpstopv1
+ * @link https://docs.dolby.io/communications-apis/reference/postrtmpstopv1
  *
  * @param consumerKey Your Dolby.io Consumer Key.
  * @param consumerSecret Your Dolby.io Consumer Secret.
@@ -113,10 +113,11 @@ export const stopRtmpBasicAuth = async (consumerKey: string, consumerSecret: str
 };
 
 /**
+ * @deprecated
  * Starts an HTTP Live Stream (HLS). The HLS URL is included in the Stream.Hls.InProgress Webhook event.
  * You must use this API if the conference is protected using enhanced conference access control.
  *
- * @link https://docs.dolby.io/interactivity/reference/posthlsstart
+ * @link https://docs.dolby.io/communications-apis/reference/posthlsstart
  *
  * @param accessToken Access token to use for authentication.
  * @param conferenceId Identifier of the conference.
@@ -139,7 +140,7 @@ export const startHls = async (accessToken: JwtToken, conferenceId: string): Pro
  * @deprecated
  * Starts an HTTP Live Stream (HLS). The HLS URL is included in the Stream.Hls.InProgress Webhook event.
  *
- * @link https://docs.dolby.io/interactivity/reference/posthlsstartv1
+ * @link https://docs.dolby.io/communications-apis/reference/posthlsstartv1
  *
  * @param consumerKey Your Dolby.io Consumer Key.
  * @param consumerSecret Your Dolby.io Consumer Secret.
@@ -162,9 +163,10 @@ export const startHlsBasicAuth = async (consumerKey: string, consumerSecret: str
 };
 
 /**
+ * @deprecated
  * Stops an HTTP Live Stream (HLS). You must use this API if the conference is protected using enhanced conference access control.
  *
- * @link https://docs.dolby.io/interactivity/reference/posthlsstop
+ * @link https://docs.dolby.io/communications-apis/reference/posthlsstop
  *
  * @param accessToken Access token to use for authentication.
  * @param conferenceId Identifier of the conference.
@@ -187,7 +189,7 @@ export const stopHls = async (accessToken: JwtToken, conferenceId: string): Prom
  * @deprecated
  * Stops an HTTP Live Stream (HLS).
  *
- * @link https://docs.dolby.io/interactivity/reference/posthlsstopv1
+ * @link https://docs.dolby.io/communications-apis/reference/posthlsstopv1
  *
  * @param consumerKey Your Dolby.io Consumer Key.
  * @param consumerSecret Your Dolby.io Consumer Secret.

--- a/src/communications/types/recordings.ts
+++ b/src/communications/types/recordings.ts
@@ -12,9 +12,9 @@ export interface GetRecordingOptions extends PagedOptions, GetRecordingsOptionsB
 }
 
 export interface MixRecording {
-    /** The size of the MP4 recording (in bytes). The MP4 recording is available only if you have requested the MP4 format in the recording settings. For more information, see the [Recording](https://docs.dolby.io/interactivity/docs/recording) document. */
+    /** The size of the MP4 recording (in bytes). The MP4 recording is available only if you have requested the MP4 format in the recording settings. For more information, see the [Recording](https://docs.dolby.io/communications-apis/docs/guides-recording-mechanisms) document. */
     mp4: number;
-    /** The size of the MP3 recording (in bytes). The MP3 recording is available only if you have requested the MP3 format in the recording settings. For more information, see the [Recording](https://docs.dolby.io/interactivity/docs/recording) document. */
+    /** The size of the MP3 recording (in bytes). The MP3 recording is available only if you have requested the MP3 format in the recording settings. For more information, see the [Recording](https://docs.dolby.io/communications-apis/docs/guides-recording-mechanisms) document. */
     mp3: number;
     /** The region code in which the mix recording took place. */
     region: string;

--- a/src/communications/types/spatialAudio.ts
+++ b/src/communications/types/spatialAudio.ts
@@ -1,0 +1,21 @@
+export interface CartesianCoordinates {
+    x: number;
+    y: number;
+    z: number;
+}
+
+export interface SpatialEnvironment {
+    scale: CartesianCoordinates;
+    forward: CartesianCoordinates;
+    up: CartesianCoordinates;
+    right: CartesianCoordinates;
+}
+
+export interface SpatialListener {
+    position: CartesianCoordinates;
+    direction: CartesianCoordinates;
+}
+
+export interface SpatialUsers {
+    [externalId: string]: CartesianCoordinates;
+}


### PR DESCRIPTION
Add support for the new [setSpatialListenersAudio](https://docs.dolby.io/communications-apis/reference/putspatiallistenersaudio) REST API.
Update the documentation links.